### PR TITLE
Make output stable

### DIFF
--- a/src/sql_entities.rs
+++ b/src/sql_entities.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 use std::rc::Rc;
 use std::vec::Vec;
 
@@ -54,7 +54,7 @@ pub struct Table {
 }
 
 // key - enum_name (type) v = enum values
-pub type SqlEnums = HashMap<String, Vec<String>>;
+pub type SqlEnums = BTreeMap<String, Vec<String>>;
 
 // ERD - entity relationship diagram
 #[derive(Clone, Debug)]

--- a/tests/sql_loader_custom_schema_test.rs
+++ b/tests/sql_loader_custom_schema_test.rs
@@ -1,5 +1,5 @@
 use sqlant::{lookup_parser, sql_entities::ColumnConstraints::*, sql_entities::*};
-use std::{collections::HashMap, env};
+use std::{collections::BTreeMap, env};
 
 mod utils;
 use crate::utils::check_fk;
@@ -13,7 +13,7 @@ fn load_erd() -> SqlERData {
 #[test]
 fn custom_schema_columns() {
     let sql_er_data: SqlERData = load_erd();
-    let tables = HashMap::from([
+    let tables = BTreeMap::from([
         (
             "customers",
             vec![

--- a/tests/sql_loader_test.rs
+++ b/tests/sql_loader_test.rs
@@ -1,5 +1,5 @@
 use sqlant::{lookup_parser, sql_entities::ColumnConstraints::*, sql_entities::*};
-use std::{collections::HashMap, env};
+use std::{collections::BTreeMap, env};
 
 mod utils;
 use crate::utils::check_fk;
@@ -13,7 +13,7 @@ fn load_erd() -> SqlERData {
 #[test]
 fn enums() {
     let sql_er_data: SqlERData = load_erd();
-    let mut expected_hash_map = HashMap::new();
+    let mut expected_hash_map = BTreeMap::new();
     expected_hash_map.insert(
         "product_category".to_string(),
         vec![
@@ -28,7 +28,7 @@ fn enums() {
 #[test]
 fn columns() {
     let sql_er_data: SqlERData = load_erd();
-    let tables = HashMap::from([
+    let tables = BTreeMap::from([
         (
             "order_detail_approval",
             vec![


### PR DESCRIPTION
Tables and columns were randomly changing positions in the output.  Now they have a stable position in the output.